### PR TITLE
Updated README to match implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ tomcat_configure_webapps: "{{ tomcat_configure }}"
 
 # These copy files across and will use basename
 tomcat_extra_libs_path: ""
-tomcat_webapps_path: ""
+tomcat_webapps_path: []
 
 # Strings That Allow you to modify your
 # tomcat instance in a predictable fashion.


### PR DESCRIPTION
README should hint the correct type for `tomcat_webapps_path`. The hint was actually a string, but the library expected an array.